### PR TITLE
Custom trigger render, minor styling & content updates, data vis test

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -51,8 +51,13 @@ module.exports = {
       console.log(err);
     }
   },
-  getJournal: (req, res) => {
-    res.render("journal.ejs");
+  getJournal: async (req, res) => {
+    try {
+      res.render("journal.ejs", { allTriggers: ['going to a bar', 'going to a party or other social event', 'going to a concert', 'seeing someone else smoke', 'being with friends who smoke', 'celebrating a big event'], trigger: req.user.triggers });
+    } catch (err) {
+      console.log(err)
+    }
+    
   },
   getFeed: async (req, res) => {
     try {
@@ -77,14 +82,14 @@ module.exports = {
         smoked: req.body.smokedToday,
         triggers: req.body.triggers,
         cravingsLevel: req.body.cravingsLevel,
+        anxietyLevel: req.body.anxietyLevel,
+        excitementLevel: req.body.excitementLevel,
         boredomLevel: req.body.boredomLevel,
         sadnessLevel: req.body.sadnessLevel,
         happinessLevel: req.body.happinessLevel,
         lonelinessLevel: req.body.lonelinessLevel,
-
-
       });
-      console.log("Post has been added!");
+      console.log("Journal entry has been added!");
       res.redirect("/profile");
     } catch (err) {
       console.log(err);

--- a/models/Journal.js
+++ b/models/Journal.js
@@ -16,23 +16,6 @@ const JournalSchema = new mongoose.Schema({
     triggers: {
         type: Array,
     },
-    // mood: {
-    //     type: String,
-    //     enum: [ 
-    //         'Accomplished', 
-    //         'Angry', 
-    //         'Anxious', 
-    //         'Bored', 
-    //         'Happy', 
-    //         'Helpless', 
-    //         'Hopeless', 
-    //         'Overwhelmed', 
-    //         'Proud', 
-    //         'Sad', 
-    //         '...'],
-    // }
-    // Mood alternative:
-    //  Choose a few different emotions, happy, anxious, etc., with a number scale from 1-10 or 1-5?
 
     // Is cravings a scale of how bad you want to smoke?
     cravingsLevel: {
@@ -40,18 +23,39 @@ const JournalSchema = new mongoose.Schema({
         min: 1,
         max: 10,
     },
+
+    //maybe wrap these in a mood object?
+    anxietyLevel: {
+        type: Number,
+        min: 1,
+        max: 10,
+    },
+    excitementLevel: {
+        type: Number,
+        min: 1,
+        max: 10,
+    },
     boredomLevel: {
-        type: Number
+        type: Number,
+        min: 1,
+        max: 10,
     },
     sadnessLevel: {
-        type: Number
+        type: Number,
+        min: 1,
+        max: 10,
     },
     happinessLevel: {
-        type: Number
+        type: Number,
+        min: 1,
+        max: 10,
     },
     lonelinessLevel: {
-        type: Number
+        type: Number,
+        min: 1,
+        max: 10,
     }
+    
 });
 
 module.exports = mongoose.model("Journal", JournalSchema);

--- a/views/journal.ejs
+++ b/views/journal.ejs
@@ -1,6 +1,6 @@
 <%- include('partials/header') -%>
-<div class="bg-gray-900 text-white">
-    <div class="mx-auto max-w-screen-xl px-4 py-32 lg:flex lg:h-screen lg:items-center">
+<div class="">
+    <div class="mx-auto max-w-screen-xl px-4 py-32 lg:flex lg:h-screen">
         <div class="col-6">
             <div class="mt-5">
               <h2>Add an Entry</h2>
@@ -18,37 +18,7 @@
 
                 <div class="mb-3">
                     <fieldset>
-                        <div>
-                            <input type="checkbox" id="anxious" name="triggers" value="anxious">
-                            <label for="stressed">Anxious</label>
-                          </div>
-                        
-                          <div>
-                            <input type="checkbox" id="excited" name="triggers" value="excited">
-                            <label for="excited">Excited</label>
-                          </div>
-
-                          <div>
-                            <input type="checkbox" id="bored" name="triggers"  value="bored">
-                            <label for="bored">Bored</label>
-                          </div>
-                        
-                          <div>
-                            <input type="checkbox" id="sad" name="triggers"  value="sad">
-                            <label for="sad">Sad</label>
-                          </div>
-
-                          <div>
-                            <input type="checkbox" id="happy" name="triggers"  value="happy">
-                            <label for="happy">Happy</label>
-                          </div>
-                        
-                          <div>
-                            <input type="checkbox" id="lonely" name="triggers"  value="lonely">
-                            <label for="lonely">Lonely</label>
-                          </div>
-                        </div>
-
+                        <legend>What triggered you? --- add functionality to only show this fieldset if user clicks yes</legend>
                         <div>
                           <p>Behavioural triggers</p>
                           <div>
@@ -127,16 +97,21 @@
                           </div>
                         
                           <div>
-                            <input type="checkbox" id="bigEvent" name="triggers"  value="Celebrating a big event">
+                            <input type="checkbox" id="bigEvent" name="triggers"  value="celebrating a big event">
                             <label for="bigEvent">Celebrating a big event</label>
                           </div>
 
                         </div>
+                        
+                        <!-- If the user entered a custom trigger during sign up, display it here -->
+                        <% if (!(allTriggers.includes(trigger[trigger.length - 1]))) { %>
+                            <div>
+                                <br>
+                                <input type="checkbox" id="<%= trigger[trigger.length - 1] %>" name="triggers"  value="<%= trigger[trigger.length - 1] %>">
+                                <label for="<%= trigger[trigger.length - 1] %>"><%= trigger[trigger.length - 1] %></label>
+                            </div>
+                        <% } %>
 
-                        <div>
-                          <label for="otherTrigger">Enter another trigger</label>
-                          <input type="text" id="otherTrigger" name="triggers" >
-                        </div>
                     </fieldset>
                 </div>
 
@@ -281,31 +256,31 @@
                             <input type="radio" id="happy1" name="happinessLevel" value="1">
                             <label for="happy1" class="form-label">1</label>
     
-                            <input type="radio" id="happy2" name="sadnessLevel" value="2">
+                            <input type="radio" id="happy2" name="happinessLevel" value="2">
                             <label for="happy2" class="form-label">2</label>
     
-                            <input type="radio" id="happy3" name="sadnessLevel" value="3">
+                            <input type="radio" id="happy3" name="happinessLevel" value="3">
                             <label for="happy3" class="form-label">3</label>
     
-                            <input type="radio" id="happy4" name="sadnessLevel" value="4">
+                            <input type="radio" id="happy4" name="happinessLevel" value="4">
                             <label for="happy4" class="form-label">4</label>
     
-                            <input type="radio" id="happy5" name="sadnessLevel" value="5">
+                            <input type="radio" id="happy5" name="happinessLevel" value="5">
                             <label for="happy5" class="form-label">5</label>
     
-                            <input type="radio" id="happy6" name="sadnessLevel" value="6">
+                            <input type="radio" id="happy6" name="happinessLevel" value="6">
                             <label for="happy6" class="form-label">6</label>
     
-                            <input type="radio" id="happy7" name="sadnessLevel" value="7">
+                            <input type="radio" id="happy7" name="happinessLevel" value="7">
                             <label for="happy7" class="form-label">7</label>
     
-                            <input type="radio" id="happy8" name="sadnessLevel" value="8">
+                            <input type="radio" id="happy8" name="happinessLevel" value="8">
                             <label for="happy8" class="form-label">8</label>
     
-                            <input type="radio" id="happy9" name="sadnessLevel" value="9">
+                            <input type="radio" id="happy9" name="happinessLevel" value="9">
                             <label for="happy9" class="form-label">9</label>
     
-                            <input type="radio" id="happy10" name="sadnessLevel" value="10">
+                            <input type="radio" id="happy10" name="happinessLevel" value="10">
                             <label for="happy10" class="form-label">10</label>
                         </fieldset>
 

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -1,7 +1,7 @@
 <%- include('partials/header') -%>
-<div class="container">
-  <div class="row mt-5">
-      <div class="col-6">
+<div class="">
+  <div class="mx-auto max-w-screen-xl px-4 py-32 lg:h-screen">
+      <div class="">
           <div>
               <p><strong>User Name</strong>: <%= user.userName %></p>
               <p><strong>Email</strong>: <%= user.email %></p>
@@ -17,6 +17,9 @@
       <div>
        
         <!--  display graph of how frequently a trigger came up         -->
+        <iframe src="https://charts.mongodb.com/charts-stop-smoking-gkmjm/public/dashboards/63770098-8226-4a27-8269-a607a5fc3c83" height="800px" width="100%"></iframe>
+        <p>text<br><br><br><br><br><br><br><br>
+        </p>
       </div>
 
       <div>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -23,7 +23,7 @@
       <div>
        
         <!--  display graph of how frequently a trigger came up         -->
-        <iframe src="https://charts.mongodb.com/charts-stop-smoking-gkmjm/public/dashboards/63770098-8226-4a27-8269-a607a5fc3c83" height="800px" width="100%"></iframe>
+        <iframe style="background: #FFFFFF;border: none;border-radius: 2px;box-shadow: 0 2px 10px 0 rgba(70, 76, 79, .2);" width="640" height="480" src="https://charts.mongodb.com/charts-stop-smoking-gkmjm/embed/charts?id=6377174b-2b1f-454d-8767-8b1d4e18f163&maxDataAge=3600&theme=light&autoRefresh=true"></iframe>
         <p>text<br><br><br><br><br><br><br><br>
         </p>
       </div>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -26,7 +26,7 @@
     />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/output.css" />
   </head>
     

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -153,33 +153,33 @@
                           <div>
                             <p>Emotional triggers</p>
                             <div>
-                              <input type="checkbox" id="anxious" name="triggers" value="anxious">
-                              <label for="stressed">Anxious</label>
+                              <input type="checkbox" id="anxious" name="triggers" value="anxiety">
+                              <label for="stressed">Anxiety</label>
                             </div>
                           
                             <div>
-                              <input type="checkbox" id="excited" name="triggers" value="excited">
-                              <label for="excited">Excited</label>
+                              <input type="checkbox" id="excited" name="triggers" value="excitement">
+                              <label for="excited">Excitement</label>
                             </div>
   
                             <div>
-                              <input type="checkbox" id="bored" name="triggers"  value="bored">
-                              <label for="bored">Bored</label>
+                              <input type="checkbox" id="bored" name="triggers"  value="boredom">
+                              <label for="bored">Boredom</label>
                             </div>
                           
                             <div>
-                              <input type="checkbox" id="sad" name="triggers"  value="sad">
-                              <label for="sad">Sad</label>
+                              <input type="checkbox" id="sad" name="triggers"  value="sadness">
+                              <label for="sad">Sadness</label>
                             </div>
   
                             <div>
-                              <input type="checkbox" id="happy" name="triggers"  value="happy">
-                              <label for="happy">Happy</label>
+                              <input type="checkbox" id="happy" name="triggers"  value="happiness">
+                              <label for="happy">Happiness</label>
                             </div>
                           
                             <div>
-                              <input type="checkbox" id="lonely" name="triggers"  value="lonely">
-                              <label for="lonely">Lonely</label>
+                              <input type="checkbox" id="lonely" name="triggers"  value="loneliness">
+                              <label for="lonely">Loneliness</label>
                             </div>
                           </div>
   


### PR DESCRIPTION
- If user adds a custom trigger during sign up, it will display as a selectable trigger on the journal entry page
- Added minor layout styling using existing tailwind code so all content is displayed
- Changed phrasing of moods on sign up page so they sound like nouns rather than verbs
- Added a couple of missing moods to the journal schema
- Started testing MongoDB Charts for user data visualization (profile page). I don't think this will work for what we need because we'll need 1+ chart for each user and I don't know that there's a way to automatically create these graphs.